### PR TITLE
fix computed props

### DIFF
--- a/vue-cardknox-ifields/src/ifields/ifields.vue
+++ b/vue-cardknox-ifields/src/ifields/ifields.vue
@@ -136,20 +136,16 @@ export default {
         this.setPlaceholder(val.placeholder);
       if (val.iFieldstyle !== oldVal.iFieldstyle)
         this.setStyle(val.iFieldstyle);
-    },
-    computed: function() {
-      return {
-        tokenValid: {
-          get() {
-            return (
-              this._tokenValid && this.xTokenData && this.xTokenData.xToken
-            );
-          },
-          set(value) {
-            this._tokenValid = value;
-          }
-        }
-      };
+    }
+  },
+  computed: {
+    tokenValid: {
+      get() {
+        return this._tokenValid && this.xTokenData && this.xTokenData.xToken;
+      },
+      set(value) {
+        this._tokenValid = value;
+      }
     }
   }
 };


### PR DESCRIPTION
bugfix

`computed` was created as a `watch` property instead of as an property of the Vue object
`computed` expects as object, not a function